### PR TITLE
fix: set right object if for course transformers

### DIFF
--- a/event_routing_backends/processors/xapi/event_transformers/progress_events.py
+++ b/event_routing_backends/processors/xapi/event_transformers/progress_events.py
@@ -1,6 +1,7 @@
 """
 Transformers for progress related events.
 """
+from django.utils.functional import cached_property
 from tincan import Activity, ActivityDefinition, Extensions, LanguageMap, Result, Verb
 
 from event_routing_backends.processors.openedx_filters.decorators import openedx_filter
@@ -34,7 +35,7 @@ class BaseProgressTransformer(XApiTransformer):
             raise NotImplementedError()
 
         return Activity(
-            id=self.get_object_iri("xblock", self.get_data("data.block_id")),
+            id=self.object_id,
             definition=ActivityDefinition(
                 type=self.object_type,
             ),
@@ -62,6 +63,11 @@ class CompletionCreatedTransformer(BaseProgressTransformer):
     """
     object_type = constants.XAPI_ACTIVITY_RESOURCE
 
+    @cached_property
+    def object_id(self):
+        """This property returns the object identifier for the completion created transformer."""
+        return super().get_object_iri("xblock", self.get_data("data.block_id"))
+
     def get_result(self):
         """
         Get result for xAPI transformed event.
@@ -86,6 +92,11 @@ class ModuleProgressTransformer(BaseProgressTransformer):
     """
     object_type = constants.XAPI_ACTIVITY_MODULE
 
+    @cached_property
+    def object_id(self):
+        """This property returns the object identifier for the module progress transformer."""
+        return super().get_object_iri("xblock", self.get_data("data.block_id"))
+
 
 @XApiTransformersRegistry.register("edx.completion_aggregator.progress.course")
 class CourseProgressTransformer(BaseProgressTransformer):
@@ -93,3 +104,8 @@ class CourseProgressTransformer(BaseProgressTransformer):
     Transformer for event generated when a user makes progress in a course.
     """
     object_type = constants.XAPI_ACTIVITY_COURSE
+
+    @cached_property
+    def object_id(self):
+        """This property returns the object identifier for the course progress transformer."""
+        return super().get_object_iri("courses", self.get_data("data.course_id"))

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.completion_aggregator.completion.course.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.completion_aggregator.completion.course.json
@@ -8,7 +8,7 @@
    },
    "id":"484fe8d7-7a5b-52ff-a0ab-3d3d8c1a8b27",
    "object":{
-      "id":"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@course+block@course",
+      "id":"http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course",
       "definition":{
          "type":"http://adlnet.gov/expapi/activities/course"
       },

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.completion_aggregator.progress.course.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.completion_aggregator.progress.course.json
@@ -8,7 +8,7 @@
    },
    "id":"146d5372-1d64-54b1-8c60-b4acaad3c976",
    "object":{
-      "id":"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@course+block@course",
+      "id":"http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course",
       "definition":{
          "type":"http://adlnet.gov/expapi/activities/course"
       },


### PR DESCRIPTION
**Description:**

Fix object id for course completion transformer and course progress transformer

## Before
![image](https://github.com/nelc/event-routing-backends/assets/36200299/b26e94d7-60c1-42c9-9671-6b4831bcaffa)


## After
![image](https://github.com/nelc/event-routing-backends/assets/36200299/d6cc0f44-55d4-4d0b-b888-4a90da68f4d7)


**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
