### PR TITLE
chore: remove context activities parent from course events

### DIFF
--- a/event_routing_backends/processors/xapi/event_transformers/completion_events.py
+++ b/event_routing_backends/processors/xapi/event_transformers/completion_events.py
@@ -68,3 +68,14 @@ class CourseCompletionTransformer(BaseCompletionTransformer):
     def object_id(self):
         """This property returns the object identifier for the course completion transformer."""
         return super().get_object_iri("courses", self.get_data("data.course_id", required=True))
+
+    def get_context_activities(self):
+        """The XApiTransformer class implements this method and returns in the parent key
+        an activity that contains the course metadata however this is not necessary in
+        cases where a transformer uses the course metadata as object since the data is
+        redundant and a course cannot be its own parent, therefore this must return None.
+
+        Returns:
+            None
+        """
+        return None

--- a/event_routing_backends/processors/xapi/event_transformers/progress_events.py
+++ b/event_routing_backends/processors/xapi/event_transformers/progress_events.py
@@ -109,3 +109,14 @@ class CourseProgressTransformer(BaseProgressTransformer):
     def object_id(self):
         """This property returns the object identifier for the course progress transformer."""
         return super().get_object_iri("courses", self.get_data("data.course_id"))
+
+    def get_context_activities(self):
+        """The XApiTransformer class implements this method and returns in the parent key
+        an activity that contains the course metadata however this is not necessary in
+        cases where a transformer uses the course metadata as object since the data is
+        redundant and a course cannot be its own parent, therefore this must return None.
+
+        Returns:
+            None
+        """
+        return None

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.completion_aggregator.completion.course.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.completion_aggregator.completion.course.json
@@ -22,20 +22,6 @@
    },
    "version":"1.0.3",
    "context":{
-      "contextActivities":{
-         "parent":[
-            {
-               "id":"http://localhost:18000/course/course-v1:edX+DemoX+Demo_Course",
-               "objectType":"Activity",
-               "definition":{
-                  "name":{
-                     "en-US":"Demonstration Course"
-                  },
-                  "type":"http://adlnet.gov/expapi/activities/course"
-               }
-            }
-         ]
-      },
       "extensions":{
          "https://w3id.org/xapi/openedx/extension/transformer-version":"event-routing-backends@1.1.1",
          "https://w3id.org/xapi/openedx/extensions/session-id":"056aca2a1c6b76742b283e73d3424453"

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.completion_aggregator.progress.course.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.completion_aggregator.progress.course.json
@@ -22,20 +22,6 @@
    },
    "version":"1.0.3",
    "context":{
-      "contextActivities":{
-         "parent":[
-            {
-               "id":"http://localhost:18000/course/course-v1:edX+DemoX+Demo_Course",
-               "objectType":"Activity",
-               "definition":{
-                  "name":{
-                     "en-US":"Demonstration Course"
-                  },
-                  "type":"http://adlnet.gov/expapi/activities/course"
-               }
-            }
-         ]
-      },
       "extensions":{
          "https://w3id.org/xapi/openedx/extension/transformer-version":"event-routing-backends@1.1.1",
          "https://w3id.org/xapi/openedx/extensions/session-id":"056aca2a1c6b76742b283e73d3424453"


### PR DESCRIPTION
**Description:** 

This removes the contextActivities from course statements, this doesn't affect the production statements since that is running async, however if this is  run synchronously or the context is updated the contextActivity key starts  to appear 

## Before
![image](https://github.com/nelc/event-routing-backends/assets/36200299/036dce3a-a0eb-463c-8bb7-a07d038f482e)


## After
![image](https://github.com/nelc/event-routing-backends/assets/36200299/bfdb1d5b-2712-4b50-af72-1b11672a40ff)



**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
