### PR TITLE
feat: add lesson transformers

### DIFF
--- a/event_routing_backends/processors/xapi/constants.py
+++ b/event_routing_backends/processors/xapi/constants.py
@@ -56,6 +56,7 @@ XAPI_ACTIVITY_PRACTICE_ASSESSMENT = 'https://w3id.org/xapi/openedx/activity/prac
 XAPI_ACTIVITY_PROCTORED_ASSESSMENT = 'https://w3id.org/xapi/openedx/activity/proctored-assessment'
 XAPI_ACTIVITY_PROGRESS = 'https://w3id.org/xapi/cmi5/result/extensions/progress'
 XAPI_ACTIVITY_CERTIFICATE = 'https://www.opigno.org/en/tincan_registry/activity_type/certificate'
+XAPI_ACTIVITY_LESSON = 'http://adlnet.gov/expapi/activities/lesson'
 
 # xAPI context
 XAPI_CONTEXT_VIDEO_LENGTH = 'https://w3id.org/xapi/video/extensions/length'

--- a/event_routing_backends/processors/xapi/event_transformers/completion_events.py
+++ b/event_routing_backends/processors/xapi/event_transformers/completion_events.py
@@ -44,10 +44,9 @@ class BaseCompletionTransformer(XApiTransformer):
 
 @XApiTransformersRegistry.register("edx.completion_aggregator.completion.chapter")
 @XApiTransformersRegistry.register("edx.completion_aggregator.completion.sequential")
-@XApiTransformersRegistry.register("edx.completion_aggregator.completion.vertical")
 class ModuleCompletionTransformer(BaseCompletionTransformer):
     """
-    Transformer for events generated when a user completes a section, subsection or unit.
+    Transformer for events generated when a user completes a section or subsection.
     """
     object_type = constants.XAPI_ACTIVITY_MODULE
 
@@ -55,6 +54,14 @@ class ModuleCompletionTransformer(BaseCompletionTransformer):
     def object_id(self):
         """This property returns the object identifier for the module completion transformer."""
         return super().get_object_iri("xblock", self.get_data("data.block_id", required=True))
+
+
+@XApiTransformersRegistry.register("edx.completion_aggregator.completion.vertical")
+class LessonCompletionTransformer(ModuleCompletionTransformer):
+    """
+    Transformer for events generated when a user completes an unit.
+    """
+    object_type = constants.XAPI_ACTIVITY_LESSON
 
 
 @XApiTransformersRegistry.register("edx.completion_aggregator.completion.course")

--- a/event_routing_backends/processors/xapi/event_transformers/progress_events.py
+++ b/event_routing_backends/processors/xapi/event_transformers/progress_events.py
@@ -85,10 +85,9 @@ class CompletionCreatedTransformer(BaseProgressTransformer):
 
 @XApiTransformersRegistry.register("edx.completion_aggregator.progress.chapter")
 @XApiTransformersRegistry.register("edx.completion_aggregator.progress.sequential")
-@XApiTransformersRegistry.register("edx.completion_aggregator.progress.vertical")
 class ModuleProgressTransformer(BaseProgressTransformer):
     """
-    Transformer for event generated when a user makes progress in a section, subsection or unit.
+    Transformer for event generated when a user makes progress in a section or subsection.
     """
     object_type = constants.XAPI_ACTIVITY_MODULE
 
@@ -96,6 +95,14 @@ class ModuleProgressTransformer(BaseProgressTransformer):
     def object_id(self):
         """This property returns the object identifier for the module progress transformer."""
         return super().get_object_iri("xblock", self.get_data("data.block_id"))
+
+
+@XApiTransformersRegistry.register("edx.completion_aggregator.progress.vertical")
+class LessonProgressTransformer(ModuleProgressTransformer):
+    """
+    Transformer for event generated when a user makes progress in an unit.
+    """
+    object_type = constants.XAPI_ACTIVITY_LESSON
 
 
 @XApiTransformersRegistry.register("edx.completion_aggregator.progress.course")

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.completion_aggregator.completion.vertical.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.completion_aggregator.completion.vertical.json
@@ -10,7 +10,7 @@
    "object":{
       "id":"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@vertical+block@e1fabd9fa55f441caa75580f258ffbc3",
       "definition":{
-         "type":"http://adlnet.gov/expapi/activities/module"
+         "type":"http://adlnet.gov/expapi/activities/lesson"
       },
       "objectType":"Activity"
    },

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.completion_aggregator.progress.vertical.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.completion_aggregator.progress.vertical.json
@@ -10,7 +10,7 @@
    "object":{
       "id":"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@vertical+block@e1fabd9fa55f441caa75580f258ffbc3",
       "definition":{
-         "type":"http://adlnet.gov/expapi/activities/module"
+         "type":"http://adlnet.gov/expapi/activities/lesson"
       },
       "objectType":"Activity"
    },


### PR DESCRIPTION
**Description:** 

This implement two new transformers, `LessonProgressTransformer` and `LessonCompletionTransformer`, and basically this changes the the object type from module to lesson for  `edx.completion_aggregator.completion.vertical `and `edx.completion_aggregator.progress.vertical ` events

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
