### PR TITLE
feat: condition completed lesson events

### DIFF
--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -45,6 +45,13 @@ def _mock_third_party_modules():
     mocked_models.get_potentially_retired_user_by_username.return_value = mocked_user
     sys.modules['common.djangoapps.student.models'] = mocked_models
 
+    # mock xmodule
+    mocked_modulestore = mock.MagicMock()
+    mocked_item = mock.MagicMock()
+    mocked_item.graded = False
+    mocked_modulestore.modulestore.return_value.get_item.return_value = mocked_item
+    sys.modules['xmodule.modulestore.django'] = mocked_modulestore
+
 
 def mocked_course_reverse(_, kwargs):
     """


### PR DESCRIPTION

**Description:** 
This checks if the lesson is graded, if so the event wont be emmited

## Result #1 A graded subsection has been completed therefore the vertical completion assessment is not sent

conditions:
1. a statement with id `...type@sequential+block@... `  and verb `attempted`  must exist 
2. a statement with id `...type@vertical+block@... `  and verb `completed`  mustn't exist 

https://github.com/nelc/event-routing-backends/assets/36200299/994f2873-ea44-4331-8923-36ded7d8ad6d


## Result #2 A non-graded subsection has been completed therefore the vertical completion assessment is sent

conditions:
1. a statement with id `...type@sequential+block@... `  and verb `attempted`  mustn't exist 
2. a statement with id `...type@vertical+block@... `  and verb `completed`  must exist 
3. 
https://github.com/nelc/event-routing-backends/assets/36200299/04cf95f0-b085-4798-99d6-e44765e260d1


**Testing instructions:**

1. Set a graded subsection and adds some problems
4. Complete any unit
5. Verify that the statement for the event `edx.completion_aggregator.completion.vertical` has not been sent
6. Check that the exception `eventtracking.processors.exceptions.EventEmissionExit` was raised 


**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
