### PR TITLE
feat: add activity lesson constant

### DIFF
--- a/event_routing_backends/processors/xapi/constants.py
+++ b/event_routing_backends/processors/xapi/constants.py
@@ -55,6 +55,7 @@ XAPI_ACTIVITY_TIMED_ASSESSMENT = 'https://w3id.org/xapi/openedx/activity/timed-a
 XAPI_ACTIVITY_PRACTICE_ASSESSMENT = 'https://w3id.org/xapi/openedx/activity/practice-assessment'
 XAPI_ACTIVITY_PROCTORED_ASSESSMENT = 'https://w3id.org/xapi/openedx/activity/proctored-assessment'
 XAPI_ACTIVITY_PROGRESS = 'https://w3id.org/xapi/cmi5/result/extensions/progress'
+XAPI_ACTIVITY_LESSON = 'http://adlnet.gov/expapi/activities/lesson'
 
 # xAPI context
 XAPI_CONTEXT_VIDEO_LENGTH = 'https://w3id.org/xapi/video/extensions/length'


### PR DESCRIPTION
## Description
This adds a new constant that is implemented in multiple library like eox-nelp and the custom version of openedx-completion-aggregator e.g https://github.com/nelc/openedx-completion-aggregator/blob/open-release/redwood.nelp/completion_aggregator/xapi.py#L71. Migration pr of https://github.com/nelc/event-routing-backends/pull/16

Issue # [1253](https://edunext.atlassian.net/browse/FUTUREX-1253)
