### PR TITLE
feat: add certificate created transformer

### DIFF
--- a/docs/technical_documentation/concepts/event-mapping/Supported_events.rst
+++ b/docs/technical_documentation/concepts/event-mapping/Supported_events.rst
@@ -89,6 +89,11 @@ Exam events
 * `edx.special_exam.proctored.attempt.submitted`_ | edX `sample <https://github.com/openedx/event-routing-backends/blob/master/event_routing_backends/processors/tests/fixtures/current/edx.special_exam.proctored.attempt.submitted.json>`__ | xAPI `sample <https://github.com/openedx/event-routing-backends/blob/master/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.special_exam.proctored.attempt.submitted.json>`__
 * `edx.special_exam.practice.attempt.submitted`_ | edX `sample <https://github.com/openedx/event-routing-backends/blob/master/event_routing_backends/processors/tests/fixtures/current/edx.special_exam.practice.attempt.submitted.json>`__ | xAPI `sample <https://github.com/openedx/event-routing-backends/blob/master/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.special_exam.practice.attempt.submitted.json>`__
 
+Certificate events
+------------------
+
+* `edx.certificate.created`_ | edX `sample <../../event_routing_backends/processors/tests/fixtures/current/edx.certificate.created.json>`__ | xAPI `map <./xAPI_mapping.rst#edx.certificate.created>`__ , `sample <../../event_routing_backends/processors/xapi/tests/fixtures/expected/edx.certificate.created.json>`__
+
 .. _edx.course.enrollment.activated: https://docs.openedx.org/en/latest/developers/references/internal_data_formats/tracking_logs/student_event_types.html#edx-course-enrollment-activated-and-edx-course-enrollment-deactivated
 .. _edx.course.enrollment.deactivated: https://docs.openedx.org/en/latest/developers/references/internal_data_formats/tracking_logs/student_event_types.html#edx-course-enrollment-activated-and-edx-course-enrollment-deactivated
 .. _edx.course.enrollment.mode_changed: https://docs.openedx.org/en/latest/developers/references/internal_data_formats/tracking_logs/student_event_types.html#edx-course-enrollment-mode-changed
@@ -141,3 +146,4 @@ Exam events
 .. _edx.special_exam.proctored.attempt.submitted: https://docs.openedx.org/en/latest/developers/references/internal_data_formats/tracking_logs/student_event_types.html#edx-special-exam-proctored-attempt-submitted-edx-special-exam-practice-attempt-submitted-and-edx-special-exam-timed-attempt-submitted
 .. _edx.special_exam.practice.attempt.created: https://docs.openedx.org/en/latest/developers/references/internal_data_formats/tracking_logs/student_event_types.html#edx-special-exam-proctored-attempt-created-edx-special-exam-practice-attempt-created-and-edx-special-exam-timed-attempt-created
 .. _edx.special_exam.practice.attempt.submitted: https://docs.openedx.org/en/latest/developers/references/internal_data_formats/tracking_logs/student_event_types.html#edx-special-exam-proctored-attempt-submitted-edx-special-exam-practice-attempt-submitted-and-edx-special-exam-timed-attempt-submitted
+.. _edx.certificate.created: https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#edx-certificate-created

--- a/docs/technical_documentation/concepts/event-mapping/xAPI_mapping.rst
+++ b/docs/technical_documentation/concepts/event-mapping/xAPI_mapping.rst
@@ -887,3 +887,24 @@ id                                                                          <LMS
 objectType                                                                  Activity
 definition [ type ]                                                         http://id.tincanapi.com/activitytype/discussion
 =========================================================================== =======================================================
+
+edx.certificate.created
+=============================
+
+=========================================================================== =======================================================
+xAPI Key                                                                    Value
+=========================================================================== =======================================================
+``Actor``
+objectType                                                                  Agent
+account [ homePage ]                                                        <LMS_ROOT_URL>
+account [ name ]                                                            <external_id[ XAPI ]>
+``Verb``
+id                                                                          http://id.tincanapi.com/verb/earned
+display [ en-US ]                                                           earned
+``Object``
+id                                                                          <LMS_ROOT_URL>/certificates/<data [ certificate_id ]>
+objectType                                                                  Activity
+definition [ type ]                                                         https://www.opigno.org/en/tincan_registry/activity_type/certificate
+definition [ name ][ en-US ]                                                Certificate <data [ course_id ]>
+definition [ extensions [ https://w3id.org/xapi/acrossx/extensions/type ] ] <data [ enrollment_mode ]>
+=========================================================================== =======================================================

--- a/docs/technical_documentation/how-tos/filters.rst
+++ b/docs/technical_documentation/how-tos/filters.rst
@@ -42,5 +42,7 @@ xAPI Filters
 +-------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
 | event_routing_backends.processors.xapi.transformer.xapi_transformer.get_context                 | Intercepts and allows to modify the xAPI object field, this affects all xAPI events|
 +-------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
+| event_routing_backends.processors.xapi.certificate_events.generated_certificates.get_object     | Allows to modify the xAPI object field, this affects certificate created           |
++-------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
 
 .. _openedx-filters: https://github.com/openedx/openedx-filters

--- a/event_routing_backends/processors/tests/fixtures/current/edx.certificate.created.json
+++ b/event_routing_backends/processors/tests/fixtures/current/edx.certificate.created.json
@@ -1,0 +1,26 @@
+{
+    "context": {
+        "accept_language": "en-US,en;q=0.9",
+        "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36",
+        "client_id": null,
+        "course_id": "course-v1:edX+DemoX+Demo_Course",
+        "host": "localhost:18000",
+        "ip": "172.18.0.1",
+        "org_id": "edX",
+        "referer": "http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/about",
+        "session": "",
+        "user_id": "",
+        "username": "",
+        "enterprise_uuid": "1a0fbcbe-49e5-42f1-8e83-4cddfa592f22"
+    },
+    "data": {
+        "course_id": "course-v1:edX+DemoX+Demo_Course",
+        "user_id": 3,
+        "certificate_id":"07b6cc1db05346c7841e587a56de0ee0",
+        "enrollment_mode":"no-id-professional",
+        "generation_mode":"self",
+        "certificate_url":"/certificates/07b6cc1db05346c7841e587a56de0ee0"
+    },
+    "name": "edx.certificate.created",
+    "timestamp": "2023-12-21T22:38:20.237535+00:00"
+}

--- a/event_routing_backends/processors/xapi/constants.py
+++ b/event_routing_backends/processors/xapi/constants.py
@@ -56,6 +56,7 @@ XAPI_ACTIVITY_PRACTICE_ASSESSMENT = 'https://w3id.org/xapi/openedx/activity/prac
 XAPI_ACTIVITY_PROCTORED_ASSESSMENT = 'https://w3id.org/xapi/openedx/activity/proctored-assessment'
 XAPI_ACTIVITY_PROGRESS = 'https://w3id.org/xapi/cmi5/result/extensions/progress'
 XAPI_ACTIVITY_LESSON = 'http://adlnet.gov/expapi/activities/lesson'
+XAPI_ACTIVITY_CERTIFICATE = 'https://www.opigno.org/en/tincan_registry/activity_type/certificate'
 
 # xAPI context
 XAPI_CONTEXT_VIDEO_LENGTH = 'https://w3id.org/xapi/video/extensions/length'

--- a/event_routing_backends/processors/xapi/event_transformers/__init__.py
+++ b/event_routing_backends/processors/xapi/event_transformers/__init__.py
@@ -2,6 +2,9 @@
 All xAPI transformers.
 """
 
+from event_routing_backends.processors.xapi.event_transformers.certificate_events import (
+    GeneratedCertificatesTransformer,
+)
 from event_routing_backends.processors.xapi.event_transformers.completion_events import CompletionCreatedTransformer
 from event_routing_backends.processors.xapi.event_transformers.enrollment_events import (
     EnrollmentActivatedTransformer,

--- a/event_routing_backends/processors/xapi/event_transformers/certificate_events.py
+++ b/event_routing_backends/processors/xapi/event_transformers/certificate_events.py
@@ -1,0 +1,44 @@
+"""
+Transformers for certificates related events.
+"""
+from tincan import Activity, ActivityDefinition, Extensions, LanguageMap, Verb
+
+from event_routing_backends.processors.openedx_filters.decorators import openedx_filter
+from event_routing_backends.processors.xapi import constants
+from event_routing_backends.processors.xapi.registry import XApiTransformersRegistry
+from event_routing_backends.processors.xapi.transformer import XApiTransformer
+
+
+@XApiTransformersRegistry.register('edx.certificate.created')
+class GeneratedCertificatesTransformer(XApiTransformer):
+    """
+    Base transformer for certificate events.
+    """
+    _verb = Verb(
+        id=constants.XAPI_VERB_EARNED,
+        display=LanguageMap({constants.EN_US: constants.EARNED}),
+    )
+
+    @openedx_filter(
+        filter_type='event_routing_backends.processors.xapi.certificate_events.generated_certificates.get_object',
+    )
+    def get_object(self):
+        """
+        Get object for xAPI transformed event.
+
+        Returns:
+            `Activity`
+        """
+        name = f"Certificate {self.get_data('data.course_id')}"
+        object_id = self.get_object_iri('certificates', self.get_data('data.certificate_id', required=True))
+
+        return Activity(
+            id=object_id,
+            definition=ActivityDefinition(
+                type=constants.XAPI_ACTIVITY_CERTIFICATE,
+                name=LanguageMap({constants.EN_US: name}),
+                extensions=Extensions({
+                    constants.XAPI_ACTIVITY_MODE: self.get_data('data.enrollment_mode')
+                })
+            ),
+        )

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.certificate.created.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.certificate.created.json
@@ -1,0 +1,48 @@
+{
+   "actor": {
+      "objectType": "Agent",
+      "account": {
+        "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+        "homePage": "http://localhost:18000"
+      }
+   },
+   "id":"28ae1567-d53d-5390-ac83-87c3f67925a3",
+   "object":{
+      "id":"http://localhost:18000/certificates/07b6cc1db05346c7841e587a56de0ee0",
+      "definition":{
+         "name":{
+            "en-US":"Certificate course-v1:edX+DemoX+Demo_Course"
+         },
+         "type":"https://www.opigno.org/en/tincan_registry/activity_type/certificate",
+         "extensions":{
+            "https://w3id.org/xapi/acrossx/extensions/type":"no-id-professional"
+         }
+      },
+      "objectType":"Activity"
+   },
+   "verb":{
+      "id":"http://id.tincanapi.com/verb/earned",
+      "display":{
+         "en-US":"earned"
+      }
+   },
+   "version":"1.0.3",
+   "context":{
+      "contextActivities":{
+         "parent":[
+            {
+               "id":"http://localhost:18000/course/course-v1:edX+DemoX+Demo_Course",
+               "objectType":"Activity",
+               "definition": {
+                  "name": { "en-US": "Demonstration Course" },
+                  "type": "http://adlnet.gov/expapi/activities/course"
+               }
+            }
+         ]
+      },
+      "extensions":{
+         "https://w3id.org/xapi/openedx/extension/transformer-version":"event-routing-backends@1.1.1"
+      }
+   },
+   "timestamp":"2023-12-21T22:38:20.237535+00:00"
+}

--- a/event_routing_backends/settings/common.py
+++ b/event_routing_backends/settings/common.py
@@ -156,6 +156,7 @@ def plugin_settings(settings):
         'edx.course.grade.passed.first_time',
         'edx.course.grade.now_passed',
         'edx.course.grade.now_failed',
+        'edx.certificate.created',
     ]
     # .. setting_name: EVENT_TRACKING_BACKENDS_ALLOWED_CALIPER_EVENTS
     # .. setting_default: [


### PR DESCRIPTION
## Description

Adds the certificate created transformer, this basically allows to register the creation event into the clickhouse database. Migration pr of https://github.com/nelc/event-routing-backends/pull/14

Issue # [1255](https://edunext.atlassian.net/browse/FUTUREX-1255)

## How to test
1. GRequest a certificate
2. Run the following query in superset `select emission_time, event from xapi.xapi_events_all order by emission_time desc;`
3. Validate the last event and verify the content

## Video reference

https://github.com/user-attachments/assets/9be0865c-1ab8-4694-be63-d9b5f550bc6c


